### PR TITLE
feat: add footer with logo  and create Terms & Privacy pages (User St…

### DIFF
--- a/src/Components/Footer.tsx
+++ b/src/Components/Footer.tsx
@@ -1,0 +1,32 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default function Footer() {
+  return (
+    <footer
+      className="flex w-full flex-col items-center justify-between gap-4 px-8 py-4 md:flex-row xl:px-[166px]"
+      style={{
+        background: 'linear-gradient(270deg, #141414 0%, #2B1E57 100%)',
+      }}>
+      <nav className="flex gap-6 text-sm font-normal text-white">
+        <Link href="/terms" className="transition hover:text-purple-300">
+          Terms and conditions
+        </Link>
+
+        <Link href="/privacy" className="transition hover:text-purple-300">
+          Privacy statement
+        </Link>
+      </nav>
+
+      <Link href="/">
+        <Image
+          src="/images/white-logo.svg"
+          alt="2DIGITS Logo"
+          width={120}
+          height={40}
+          className="md:w-[200px]"
+        />
+      </Link>
+    </footer>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter, Open_Sans, Roboto } from 'next/font/google';
 import Header from '@/Components/Header';
 
 import './globals.css';
+
 import Footer from '@/Components/Footer';
 
 const inter = Inter({ subsets: ['latin'] });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter, Open_Sans, Roboto } from 'next/font/google';
 import Header from '@/Components/Header';
 
 import './globals.css';
+import Footer from '@/Components/Footer';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -31,6 +32,8 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
         <Header />
 
         {children}
+
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export default async function Home() {
           {Page?.page_header?.title}
         </p>
 
-        <div className="fixed bottom-0 left-0 flex h-48 w-full items-end justify-center bg-gradient-to-t from-white via-white lg:static lg:size-auto lg:bg-none dark:from-black dark:via-black">
+        <div className="fixed hidden bottom-0 left-0 sm:flex h-48 w-full items-end justify-center bg-gradient-to-t from-white via-white lg:static lg:size-auto lg:bg-none dark:from-black dark:via-black">
           <a
             className="pointer-events-none flex place-items-center gap-2 p-8 lg:pointer-events-auto lg:p-0"
             href="https://vercel.com?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export default async function Home() {
           {Page?.page_header?.title}
         </p>
 
-        <div className="fixed hidden bottom-0 left-0 sm:flex h-48 w-full items-end justify-center bg-gradient-to-t from-white via-white lg:static lg:size-auto lg:bg-none dark:from-black dark:via-black">
+        <div className="fixed bottom-0 left-0 hidden h-48 w-full items-end justify-center bg-gradient-to-t from-white via-white sm:flex lg:static lg:size-auto lg:bg-none dark:from-black dark:via-black">
           <a
             className="pointer-events-none flex place-items-center gap-2 p-8 lg:pointer-events-auto lg:p-0"
             href="https://vercel.com?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -25,7 +25,7 @@ export default function PrivacyPage() {
                 <li>Technical information about your device and browser</li>
 
                 <li>Usage data and analytics about how you interact with our website</li>
-                
+
                 <li>Cookies and similar tracking technologies</li>
               </ul>
             </section>
@@ -36,7 +36,6 @@ export default function PrivacyPage() {
               </h2>
 
               <p className="mb-4 text-gray-700">
-
                 We use the collected information for the following purposes:
               </p>
 
@@ -55,7 +54,7 @@ export default function PrivacyPage() {
 
             <section className="mb-8">
               <h2 className="mb-4 text-2xl font-semibold text-gray-900">Data Protection</h2>
-              
+
               <p className="text-gray-700">
                 We implement appropriate technical and organizational measures to protect your
                 personal data against unauthorized access, alteration, disclosure, or destruction.
@@ -118,7 +117,7 @@ export default function PrivacyPage() {
 
             <section className="rounded-lg bg-gray-50 p-6">
               <h2 className="mb-4 text-2xl font-semibold text-gray-900">Contact Us</h2>
-              
+
               <p className="mb-4 text-gray-700">
                 If you have any questions about this Privacy Statement or our data practices, please
                 contact us:
@@ -132,7 +131,7 @@ export default function PrivacyPage() {
                 <p className="mb-2">
                   <strong>Address:</strong> 2DIGITS Agency, [Your Address]
                 </p>
-                
+
                 <p>
                   <strong>Phone:</strong> [Your Phone Number]
                 </p>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,150 @@
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-4xl px-6 py-16 md:px-8">
+        <div className="rounded-lg bg-white p-8 shadow-sm md:p-12">
+          <h1 className="mb-8 text-4xl font-bold text-gray-900">Privacy Statement</h1>
+
+          <div className="prose prose-lg max-w-none">
+            <p className="mb-8 text-lg text-gray-600">
+              At 2DIGITS, we are committed to protecting your privacy and ensuring the security of
+              your personal information. This Privacy Statement explains how we collect, use, and
+              safeguard your data.
+            </p>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Information We Collect</h2>
+
+              <p className="mb-4 text-gray-700">
+                We may collect the following types of information:
+              </p>
+
+              <ul className="ml-4 list-inside list-disc space-y-2 text-gray-700">
+                <li>Personal identification information (name, email address, phone number)</li>
+
+                <li>Technical information about your device and browser</li>
+
+                <li>Usage data and analytics about how you interact with our website</li>
+                
+                <li>Cookies and similar tracking technologies</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">
+                How We Use Your Information
+              </h2>
+
+              <p className="mb-4 text-gray-700">
+
+                We use the collected information for the following purposes:
+              </p>
+
+              <ul className="ml-4 list-inside list-disc space-y-2 text-gray-700">
+                <li>To provide and maintain our services</li>
+
+                <li>To communicate with you about our products and services</li>
+
+                <li>To improve our website and user experience</li>
+
+                <li>To comply with legal obligations</li>
+
+                <li>To protect against fraud and security threats</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Data Protection</h2>
+              
+              <p className="text-gray-700">
+                We implement appropriate technical and organizational measures to protect your
+                personal data against unauthorized access, alteration, disclosure, or destruction.
+                Your data is stored securely and is only accessible by authorized personnel who need
+                it to perform their job functions.
+              </p>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Your Rights</h2>
+
+              <p className="mb-4 text-gray-700">
+                Under applicable data protection laws, you have the right to:
+              </p>
+
+              <ul className="ml-4 list-inside list-disc space-y-2 text-gray-700">
+                <li>Access your personal data</li>
+
+                <li>Correct inaccurate or incomplete data</li>
+
+                <li>Request deletion of your data</li>
+
+                <li>Object to or restrict processing of your data</li>
+
+                <li>Data portability</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Cookies</h2>
+
+              <p className="text-gray-700">
+                Our website uses cookies to enhance your browsing experience and provide
+                personalized content. You can manage your cookie preferences through your browser
+                settings. However, disabling certain cookies may affect the functionality of our
+                website.
+              </p>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Third-Party Services</h2>
+
+              <p className="text-gray-700">
+                We may use third-party services for analytics, advertising, and other purposes.
+                These services may have their own privacy policies, and we encourage you to review
+                them. We are not responsible for the privacy practices of third-party websites or
+                services.
+              </p>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Changes to This Policy</h2>
+
+              <p className="text-gray-700">
+                We may update this Privacy Statement from time to time to reflect changes in our
+                practices or applicable laws. We will notify you of any material changes by posting
+                the updated policy on our website with a new effective date.
+              </p>
+            </section>
+
+            <section className="rounded-lg bg-gray-50 p-6">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Contact Us</h2>
+              
+              <p className="mb-4 text-gray-700">
+                If you have any questions about this Privacy Statement or our data practices, please
+                contact us:
+              </p>
+
+              <div className="text-gray-700">
+                <p className="mb-2">
+                  <strong>Email:</strong> privacy@2digits.com
+                </p>
+
+                <p className="mb-2">
+                  <strong>Address:</strong> 2DIGITS Agency, [Your Address]
+                </p>
+                
+                <p>
+                  <strong>Phone:</strong> [Your Phone Number]
+                </p>
+              </div>
+            </section>
+
+            <div className="mt-8 border-t border-gray-200 pt-6">
+              <p className="text-sm text-gray-500">Last updated: August 5, 2025</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -24,9 +24,9 @@ export default function TermsPage() {
             <section className="mb-8">
               <h2 className="mb-4 text-2xl font-semibold text-gray-900">Use License</h2>
               <p className="mb-4 text-gray-700">
-                Permission is granted to temporarily download one copy of the materials on 2DIGITS&apos;
-                website for personal, non-commercial transitory viewing only. This is the grant of a
-                license, not a transfer of title, and under this license you may not:
+                Permission is granted to temporarily download one copy of the materials on
+                2DIGITS&apos; website for personal, non-commercial transitory viewing only. This is
+                the grant of a license, not a transfer of title, and under this license you may not:
               </p>
               <ul className="ml-4 list-inside list-disc space-y-2 text-gray-700">
                 <li>Modify or copy the materials</li>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,171 @@
+/* eslint-disable react/jsx-newline */
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-4xl px-6 py-16 md:px-8">
+        <div className="rounded-lg bg-white p-8 shadow-sm md:p-12">
+          <h1 className="mb-8 text-4xl font-bold text-gray-900">Terms and Conditions</h1>
+
+          <div className="prose prose-lg max-w-none">
+            <p className="mb-8 text-lg text-gray-600">
+              Welcome to 2DIGITS. These Terms and Conditions govern your use of our website and
+              services. By accessing or using our services, you agree to be bound by these terms.
+            </p>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Acceptance of Terms</h2>
+              <p className="text-gray-700">
+                By accessing and using this website, you accept and agree to be bound by the terms
+                and provision of this agreement. If you do not agree to abide by the above, please
+                do not use this service.
+              </p>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Use License</h2>
+              <p className="mb-4 text-gray-700">
+                Permission is granted to temporarily download one copy of the materials on 2DIGITS&apos;
+                website for personal, non-commercial transitory viewing only. This is the grant of a
+                license, not a transfer of title, and under this license you may not:
+              </p>
+              <ul className="ml-4 list-inside list-disc space-y-2 text-gray-700">
+                <li>Modify or copy the materials</li>
+                <li>Use the materials for any commercial purpose or for any public display</li>
+                <li>Attempt to reverse engineer any software contained on the website</li>
+                <li>Remove any copyright or other proprietary notations from the materials</li>
+              </ul>
+              <p className="mt-4 text-gray-700">
+                This license shall automatically terminate if you violate any of these restrictions
+                and may be terminated by 2DIGITS at any time.
+              </p>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">User Accounts</h2>
+              <p className="mb-4 text-gray-700">
+                When you create an account with us, you must provide information that is accurate,
+                complete, and current at all times. You are responsible for:
+              </p>
+              <ul className="ml-4 list-inside list-disc space-y-2 text-gray-700">
+                <li>Safeguarding the password and all activities under your account</li>
+                <li>Notifying us immediately of any unauthorized use of your account</li>
+                <li>Ensuring your account information remains accurate and up-to-date</li>
+                <li>Complying with all applicable laws and regulations</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Prohibited Uses</h2>
+              <p className="mb-4 text-gray-700">
+                You may not use our services for any unlawful purpose or to solicit others to
+                perform unlawful acts. Prohibited uses include, but are not limited to:
+              </p>
+              <ul className="ml-4 list-inside list-disc space-y-2 text-gray-700">
+                <li>Violating any applicable laws or regulations</li>
+                <li>Transmitting malicious code, viruses, or harmful software</li>
+                <li>Attempting to gain unauthorized access to our systems</li>
+                <li>Harassing, abusing, or harming other users</li>
+                <li>Engaging in fraudulent or deceptive practices</li>
+                <li>Infringing on intellectual property rights</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">
+                Content and Intellectual Property
+              </h2>
+              <p className="mb-4 text-gray-700">
+                All content on this website, including but not limited to text, graphics, logos,
+                images, and software, is the property of 2DIGITS or its content suppliers and is
+                protected by international copyright laws.
+              </p>
+              <p className="text-gray-700">
+                You retain rights to any content you submit, post, or display on or through our
+                services. By submitting content, you grant us a worldwide, non-exclusive,
+                royalty-free license to use, reproduce, and distribute such content.
+              </p>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Service Availability</h2>
+              <p className="text-gray-700">
+                We strive to maintain the availability of our services, but we do not guarantee
+                uninterrupted access. We reserve the right to modify, suspend, or discontinue any
+                part of our services at any time without prior notice.
+              </p>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Limitation of Liability</h2>
+              <p className="text-gray-700">
+                In no event shall 2DIGITS or its suppliers be liable for any damages (including,
+                without limitation, damages for loss of data or profit, or due to business
+                interruption) arising out of the use or inability to use the materials on our
+                website, even if 2DIGITS or an authorized representative has been notified of the
+                possibility of such damage.
+              </p>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Privacy Policy</h2>
+              <p className="text-gray-700">
+                Your privacy is important to us. Please review our Privacy Policy, which also
+                governs your use of our services, to understand our practices regarding the
+                collection and use of your personal information.
+              </p>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Termination</h2>
+              <p className="text-gray-700">
+                We may terminate or suspend your account and access to our services immediately,
+                without prior notice or liability, for any reason, including if you breach these
+                Terms and Conditions.
+              </p>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Changes to Terms</h2>
+              <p className="text-gray-700">
+                We reserve the right to update or modify these Terms and Conditions at any time
+                without prior notice. Your continued use of our services after any changes
+                constitutes your acceptance of the new terms.
+              </p>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Governing Law</h2>
+              <p className="text-gray-700">
+                These Terms and Conditions are governed by and construed in accordance with the laws
+                of [Your Jurisdiction], and you irrevocably submit to the exclusive jurisdiction of
+                the courts in that state or location.
+              </p>
+            </section>
+
+            <section className="rounded-lg bg-gray-50 p-6">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900">Contact Information</h2>
+              <p className="mb-4 text-gray-700">
+                If you have any questions about these Terms and Conditions, please contact us:
+              </p>
+              <div className="text-gray-700">
+                <p className="mb-2">
+                  <strong>Email:</strong> legal@2digits.com
+                </p>
+                <p className="mb-2">
+                  <strong>Address:</strong> 2DIGITS Agency, [Your Address]
+                </p>
+                <p>
+                  <strong>Phone:</strong> [Your Phone Number]
+                </p>
+              </div>
+            </section>
+
+            <div className="mt-8 border-t border-gray-200 pt-6">
+              <p className="text-sm text-gray-500">Last updated: August 5, 2025</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR implements the footer section as described in User Story 2. It includes:

A footer component with quicklinks (About, Blogs, Contact, Terms, Privacy).

Responsive layout matching the design.

Static pages for "Terms" and "Privacy" created under src/app/.

Linked routes working correctly with next/link.